### PR TITLE
feat: 카테고리 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Mapper
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/sch/rezero/config/config.java
+++ b/src/main/java/sch/rezero/config/config.java
@@ -1,5 +1,0 @@
-package sch.rezero.config;
-
-public class config {
-
-}

--- a/src/main/java/sch/rezero/config/exception/ApiException.java
+++ b/src/main/java/sch/rezero/config/exception/ApiException.java
@@ -1,0 +1,16 @@
+package sch.rezero.config.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String description;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+        this.description = errorCode.getDescription();
+    }
+}

--- a/src/main/java/sch/rezero/config/exception/ApiExceptionHandler.java
+++ b/src/main/java/sch/rezero/config/exception/ApiExceptionHandler.java
@@ -22,4 +22,28 @@ public class ApiExceptionHandler {
                              .body(response);
     }
 
+
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException exception) {
+        log.error("Exception occurred: {}, time: {}", exception.getMessage(), LocalDateTime.now());
+
+        ErrorCode errorCode = GlobalErrorCode.BAD_REQUEST;
+        ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getDescription(),
+            errorCode.getHttpStatus());
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                             .body(response);
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception exception) {
+        log.error("Exception occurred: {}, time: {}", exception.getMessage(), LocalDateTime.now());
+
+        ErrorCode errorCode = GlobalErrorCode.SERVER_ERROR;
+        ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getDescription(),
+            errorCode.getHttpStatus());
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                             .body(response);
+    }
 }

--- a/src/main/java/sch/rezero/config/exception/ApiExceptionHandler.java
+++ b/src/main/java/sch/rezero/config/exception/ApiExceptionHandler.java
@@ -1,0 +1,25 @@
+package sch.rezero.config.exception;
+
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(value = ApiException.class)
+    public ResponseEntity<ErrorResponse> handleException(ApiException exception) {
+        log.error("Exception occurred: {}, time: {}", exception.getMessage(), LocalDateTime.now());
+
+        ErrorCode errorCode = exception.getErrorCode();
+        ErrorResponse response = new ErrorResponse(errorCode.getCode(), errorCode.getDescription(),
+            errorCode.getHttpStatus());
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                             .body(response);
+    }
+
+}

--- a/src/main/java/sch/rezero/config/exception/ErrorCode.java
+++ b/src/main/java/sch/rezero/config/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package sch.rezero.config.exception;
+
+public interface ErrorCode {
+
+    String getCode();
+
+    String getDescription();
+
+    Integer getHttpStatus();
+}

--- a/src/main/java/sch/rezero/config/exception/ErrorResponse.java
+++ b/src/main/java/sch/rezero/config/exception/ErrorResponse.java
@@ -1,0 +1,9 @@
+package sch.rezero.config.exception;
+
+public record ErrorResponse(
+    String code,
+    String description,
+    Integer httpStatus
+) {
+
+}

--- a/src/main/java/sch/rezero/config/exception/GlobalErrorCode.java
+++ b/src/main/java/sch/rezero/config/exception/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package sch.rezero.config.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    BAD_REQUEST("400", "잘못된 요청입니다", HttpStatus.BAD_REQUEST.value()),
+    SERVER_ERROR("500", "서버 에러", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    ;
+
+    private final String code;
+    private final String description;
+    private final Integer httpStatus;
+}

--- a/src/main/java/sch/rezero/domain/category/controller/CategoryController.java
+++ b/src/main/java/sch/rezero/domain/category/controller/CategoryController.java
@@ -1,12 +1,67 @@
 package sch.rezero.domain.category.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sch.rezero.domain.category.dto.request.CategoryCreateRequest;
+import sch.rezero.domain.category.dto.request.CategoryUpdateRequest;
+import sch.rezero.domain.category.dto.response.CategoryResponse;
+import sch.rezero.domain.category.service.CategoryService;
 
 @RestController
 @RequestMapping("/api/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 
+    private final CategoryService categoryService;
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryResponse> getCategory(@PathVariable Long categoryId) {
+        CategoryResponse category = categoryService.findById(categoryId);
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(category);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> getCategories() {
+        List<CategoryResponse> categories = categoryService.findAll();
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(categories);
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoryResponse> createCategory(@RequestBody CategoryCreateRequest request) {
+        CategoryResponse category = categoryService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(category);
+    }
+
+    @PatchMapping("/{categoryId}")
+    public ResponseEntity<CategoryResponse> updateCategory(@PathVariable Long categoryId,
+        @RequestBody CategoryUpdateRequest request) {
+        CategoryResponse category = categoryService.update(request, categoryId);
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(category);
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<CategoryResponse> deleteCategory(@PathVariable Long categoryId) {
+        CategoryResponse category = categoryService.softDelete(categoryId);
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(category);
+    }
+
+    @DeleteMapping("/{categoryId}/hard")
+    public void hardDeleteCategory(@PathVariable Long categoryId) {
+        categoryService.hardDelete(categoryId);
+    }
 }

--- a/src/main/java/sch/rezero/domain/category/controller/CategoryController.java
+++ b/src/main/java/sch/rezero/domain/category/controller/CategoryController.java
@@ -48,7 +48,7 @@ public class CategoryController {
     @PatchMapping("/{categoryId}")
     public ResponseEntity<CategoryResponse> updateCategory(@PathVariable Long categoryId,
         @RequestBody CategoryUpdateRequest request) {
-        CategoryResponse category = categoryService.update(request, categoryId);
+        CategoryResponse category = categoryService.update(categoryId, request);
         return ResponseEntity.status(HttpStatus.OK)
                              .body(category);
     }

--- a/src/main/java/sch/rezero/domain/category/entity/Category.java
+++ b/src/main/java/sch/rezero/domain/category/entity/Category.java
@@ -9,11 +9,14 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import sch.rezero.domain.category.dto.request.CategoryUpdateRequest;
 
+@Builder
 @Entity
 @Getter
 @Table(name = "categories")
@@ -36,4 +39,17 @@ public class Category {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void updateCategory(CategoryUpdateRequest request) {
+        if (request.category() != null && !request.category()
+                                                  .isEmpty()) {
+            this.category = request.category();
+        }
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/sch/rezero/domain/category/exception/CategoryErrorCode.java
+++ b/src/main/java/sch/rezero/domain/category/exception/CategoryErrorCode.java
@@ -1,0 +1,18 @@
+package sch.rezero.domain.category.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import sch.rezero.config.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+    DUPLICATE_CATEGORY_NAME("C001", "이미 존재하는 카테고리 이름입니다.", HttpStatus.BAD_REQUEST.value()),
+    CATEGORY_NOT_FOUND("C002", "존재하지 않는 카테고리 아이디입니다.", HttpStatus.NOT_FOUND.value())
+    ;
+
+    private final String code;
+    private final String description;
+    private final Integer httpStatus;
+}

--- a/src/main/java/sch/rezero/domain/category/exception/CategoryErrorCode.java
+++ b/src/main/java/sch/rezero/domain/category/exception/CategoryErrorCode.java
@@ -9,8 +9,8 @@ import sch.rezero.config.exception.ErrorCode;
 @AllArgsConstructor
 public enum CategoryErrorCode implements ErrorCode {
     DUPLICATE_CATEGORY_NAME("C001", "이미 존재하는 카테고리 이름입니다.", HttpStatus.BAD_REQUEST.value()),
-    CATEGORY_NOT_FOUND("C002", "존재하지 않는 카테고리 아이디입니다.", HttpStatus.NOT_FOUND.value())
-    ;
+    CATEGORY_NOT_FOUND("C002", "존재하지 않는 카테고리 아이디입니다.", HttpStatus.NOT_FOUND.value()),
+    CATEGORY_DELETED("C003", "삭제된 카테고리입니다.", HttpStatus.GONE.value());
 
     private final String code;
     private final String description;

--- a/src/main/java/sch/rezero/domain/category/mapper/CategoryMapper.java
+++ b/src/main/java/sch/rezero/domain/category/mapper/CategoryMapper.java
@@ -1,0 +1,11 @@
+package sch.rezero.domain.category.mapper;
+
+import org.mapstruct.Mapper;
+import sch.rezero.domain.category.dto.response.CategoryResponse;
+import sch.rezero.domain.category.entity.Category;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+
+    CategoryResponse toDto(Category category);
+}

--- a/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
@@ -7,5 +7,7 @@ import sch.rezero.domain.category.entity.Category;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    boolean existsByCategory(String category);
+    boolean existsByCategoryAndDeletedAtIsNull(String category);
+
+    boolean existsByCategoryAndIdNot(String category, Long id);
 }

--- a/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
@@ -9,5 +9,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     boolean existsByCategoryAndDeletedAtIsNull(String category);
 
-    boolean existsByCategoryAndIdNot(String category, Long id);
+    boolean existsByCategoryAndIdNotAndDeletedAtIsNull(String category, Long id);
 }

--- a/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
@@ -9,5 +9,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     boolean existsByCategoryAndDeletedAtIsNull(String category);
 
-    boolean existsByCategoryAndIdNotAndDeletedAtIsNull(String category, Long id);
+    boolean existsByCategoryAndIdNot(String category, Long id);
 }

--- a/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/sch/rezero/domain/category/repository/CategoryRepository.java
@@ -7,4 +7,5 @@ import sch.rezero.domain.category.entity.Category;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    boolean existsByCategory(String category);
 }

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -57,7 +57,7 @@ public class CategoryService {
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
-        if (categoryRepository.existsByCategoryAndIdNot(request.category(), id)) {
+        if (categoryRepository.existsByCategoryAndIdNotAndDeletedAtIsNull(request.category(), id)) {
             throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -39,6 +39,10 @@ public class CategoryService {
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
+        if (category.getDeletedAt() != null) {
+            throw new ApiException(CategoryErrorCode.CATEGORY_DELETED);
+        }
+
         return categoryMapper.toDto(category);
     }
 

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package sch.rezero.domain.category.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sch.rezero.config.exception.ApiException;
 import sch.rezero.domain.category.dto.request.CategoryCreateRequest;
 import sch.rezero.domain.category.dto.request.CategoryUpdateRequest;
@@ -19,6 +20,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
 
+    @Transactional
     public CategoryResponse create(CategoryCreateRequest request) {
         if (categoryRepository.existsByCategory(request.category())) {
             throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
@@ -31,6 +33,7 @@ public class CategoryService {
         return categoryMapper.toDto(categoryRepository.save(category));
     }
 
+    @Transactional(readOnly = true)
     public CategoryResponse findById(Long id) {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(
@@ -40,6 +43,7 @@ public class CategoryService {
     }
 
     //TODO : 추후 페이지네이션으로 구현
+    @Transactional(readOnly = true)
     public List<CategoryResponse> findAll() {
         return categoryRepository.findAll()
                                  .stream()
@@ -47,21 +51,30 @@ public class CategoryService {
                                  .toList();
     }
 
+    @Transactional
     public CategoryResponse update(CategoryUpdateRequest request, Long id) {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        if (categoryRepository.existsByCategory(request.category())) {
+            throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
+        }
+
         category.updateCategory(request);
         return categoryMapper.toDto(categoryRepository.save(category));
     }
 
-    public void softDelete(Long id) {
+    @Transactional
+    public CategoryResponse softDelete(Long id) {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
         category.softDelete();
+        return categoryMapper.toDto(category);
     }
 
+    @Transactional
     public void hardDelete(Long id) {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -57,7 +57,11 @@ public class CategoryService {
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
-        if (categoryRepository.existsByCategoryAndIdNotAndDeletedAtIsNull(request.category(), id)) {
+        if (category.getDeletedAt() != null) {
+            throw new ApiException(CategoryErrorCode.CATEGORY_DELETED);
+        }
+
+        if (categoryRepository.existsByCategoryAndIdNot(request.category(), id)) {
             throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 
@@ -70,6 +74,11 @@ public class CategoryService {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        if (category.getDeletedAt() != null) {
+            throw new ApiException(CategoryErrorCode.CATEGORY_DELETED);
+        }
+
         category.softDelete();
         return categoryMapper.toDto(category);
     }

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -1,10 +1,71 @@
 package sch.rezero.domain.category.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import sch.rezero.config.exception.ApiException;
+import sch.rezero.domain.category.dto.request.CategoryCreateRequest;
+import sch.rezero.domain.category.dto.request.CategoryUpdateRequest;
+import sch.rezero.domain.category.dto.response.CategoryResponse;
+import sch.rezero.domain.category.entity.Category;
+import sch.rezero.domain.category.exception.CategoryErrorCode;
+import sch.rezero.domain.category.mapper.CategoryMapper;
+import sch.rezero.domain.category.repository.CategoryRepository;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
 
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    public CategoryResponse create(CategoryCreateRequest request) {
+        if (categoryRepository.existsByCategory(request.category())) {
+            throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
+        }
+
+        Category category = Category.builder()
+                                    .category(request.category())
+                                    .build();
+
+        return categoryMapper.toDto(categoryRepository.save(category));
+    }
+
+    public CategoryResponse findById(Long id) {
+        Category category = categoryRepository.findById(id)
+                                              .orElseThrow(
+                                                  () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        return categoryMapper.toDto(category);
+    }
+
+    //TODO : 추후 페이지네이션으로 구현
+    public List<CategoryResponse> findAll() {
+        return categoryRepository.findAll()
+                                 .stream()
+                                 .map(categoryMapper::toDto)
+                                 .toList();
+    }
+
+    public CategoryResponse update(CategoryUpdateRequest request, Long id) {
+        Category category = categoryRepository.findById(id)
+                                              .orElseThrow(
+                                                  () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+        category.updateCategory(request);
+        return categoryMapper.toDto(categoryRepository.save(category));
+    }
+
+    public void softDelete(Long id) {
+        Category category = categoryRepository.findById(id)
+                                              .orElseThrow(
+                                                  () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+        category.softDelete();
+    }
+
+    public void hardDelete(Long id) {
+        Category category = categoryRepository.findById(id)
+                                              .orElseThrow(
+                                                  () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+        categoryRepository.delete(category);
+    }
 }

--- a/src/main/java/sch/rezero/domain/category/service/CategoryService.java
+++ b/src/main/java/sch/rezero/domain/category/service/CategoryService.java
@@ -22,7 +22,7 @@ public class CategoryService {
 
     @Transactional
     public CategoryResponse create(CategoryCreateRequest request) {
-        if (categoryRepository.existsByCategory(request.category())) {
+        if (categoryRepository.existsByCategoryAndDeletedAtIsNull(request.category())) {
             throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 
@@ -52,12 +52,12 @@ public class CategoryService {
     }
 
     @Transactional
-    public CategoryResponse update(CategoryUpdateRequest request, Long id) {
+    public CategoryResponse update(Long id, CategoryUpdateRequest request) {
         Category category = categoryRepository.findById(id)
                                               .orElseThrow(
                                                   () -> new ApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
-        if (categoryRepository.existsByCategory(request.category())) {
+        if (categoryRepository.existsByCategoryAndIdNot(request.category(), id)) {
             throw new ApiException(CategoryErrorCode.DUPLICATE_CATEGORY_NAME);
         }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS group_members CASCADE;
-DROP TABLE IF EXISTS category CASCADE;
+DROP TABLE IF EXISTS categories CASCADE;
 DROP TABLE IF EXISTS reviews CASCADE;
 DROP TABLE IF EXISTS `groups` CASCADE;
 DROP TABLE IF EXISTS complaints CASCADE;
@@ -52,12 +52,13 @@ CREATE TABLE group_members
     CONSTRAINT FK_groups_group_members FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE CASCADE
 );
 
-CREATE TABLE category
+CREATE TABLE categories
 (
     id         BIGINT PRIMARY KEY,
     category   VARCHAR(20) NOT NULL,
     created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
 );
 
 CREATE TABLE stores
@@ -122,7 +123,7 @@ CREATE TABLE recycling_posts
     thumb_nail_image VARCHAR(255) NOT NULL,
     deleted_at       TIMESTAMP,
     CONSTRAINT FK_users_recycling_posts FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
-    CONSTRAINT FK_category_recycling_posts FOREIGN KEY (category_id) REFERENCES category (id) ON DELETE CASCADE
+    CONSTRAINT FK_category_recycling_posts FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
 );
 
 CREATE TABLE scraps
@@ -138,11 +139,11 @@ CREATE TABLE scraps
 
 CREATE TABLE popular_posts
 (
-    id      BIGINT PRIMARY KEY,
-    post_id BIGINT NOT NULL,
+    id       BIGINT PRIMARY KEY,
+    post_id  BIGINT      NOT NULL,
     `period` VARCHAR(20) NOT NULL,
-    `rank`  BIGINT NOT NULL,
-    score   INT    NOT NULL,
+    `rank`   BIGINT      NOT NULL,
+    score    INT         NOT NULL,
     CONSTRAINT FK_recycling_posts_popular_posts FOREIGN KEY (post_id) REFERENCES recycling_posts (id) ON DELETE CASCADE
 );
 
@@ -176,5 +177,5 @@ CREATE TABLE interests
     category_id BIGINT NOT NULL,
     PRIMARY KEY (user_id, category_id),
     CONSTRAINT FK_users_interests FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
-    CONSTRAINT FK_category_interests FOREIGN KEY (category_id) REFERENCES category (id) ON DELETE CASCADE
+    CONSTRAINT FK_category_interests FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,7 +15,7 @@ DROP TABLE IF EXISTS interests CASCADE;
 
 CREATE TABLE users
 (
-    id              BIGINT PRIMARY KEY,
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
     login_id        VARCHAR(50)  NOT NULL UNIQUE,
     password        VARCHAR(50)  NOT NULL,
     name            VARCHAR(100) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE users
 
 CREATE TABLE `groups`
 (
-    id          BIGINT PRIMARY KEY,
+    id          BIGINT PRIMARY KEY AUTO_INCREMENT,
     leader_id   BIGINT      NOT NULL,
     name        VARCHAR(50) NOT NULL,
     description VARCHAR(255),
@@ -42,7 +42,7 @@ CREATE TABLE `groups`
 
 CREATE TABLE group_members
 (
-    id        BIGINT PRIMARY KEY,
+    id        BIGINT PRIMARY KEY AUTO_INCREMENT,
     user_id   BIGINT    NOT NULL,
     group_id  BIGINT    NOT NULL,
     approved  BOOLEAN   NOT NULL DEFAULT FALSE,
@@ -54,7 +54,7 @@ CREATE TABLE group_members
 
 CREATE TABLE categories
 (
-    id         BIGINT PRIMARY KEY,
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
     category   VARCHAR(20) NOT NULL,
     created_at TIMESTAMP   NOT NULL,
     updated_at TIMESTAMP,
@@ -63,7 +63,7 @@ CREATE TABLE categories
 
 CREATE TABLE stores
 (
-    id              BIGINT PRIMARY KEY,
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
     name            VARCHAR(255)   NOT NULL,
     address         VARCHAR(500)   NOT NULL,
     lat             DECIMAL(10, 7) NOT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE stores
 
 CREATE TABLE reviews
 (
-    id         BIGINT PRIMARY KEY,
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
     user_id    BIGINT    NOT NULL,
     store_id   BIGINT    NOT NULL,
     content    TEXT      NOT NULL,
@@ -86,7 +86,7 @@ CREATE TABLE reviews
 
 CREATE TABLE complaints
 (
-    id          BIGINT PRIMARY KEY,
+    id          BIGINT PRIMARY KEY AUTO_INCREMENT,
     reporter_id BIGINT      NOT NULL,
     reported_id BIGINT      NOT NULL,
     reason      TEXT        NOT NULL,
@@ -100,7 +100,7 @@ CREATE TABLE complaints
 
 CREATE TABLE notifications
 (
-    notification_id BIGINT PRIMARY KEY,
+    notification_id BIGINT PRIMARY KEY AUTO_INCREMENT,
     user_id         BIGINT       NOT NULL,
     title           VARCHAR(100) NOT NULL,
     content         VARCHAR(500) NOT NULL,
@@ -113,7 +113,7 @@ CREATE TABLE notifications
 
 CREATE TABLE recycling_posts
 (
-    id               BIGINT PRIMARY KEY,
+    id               BIGINT PRIMARY KEY AUTO_INCREMENT,
     user_id          BIGINT       NOT NULL,
     category_id      BIGINT       NOT NULL,
     title            VARCHAR(255) NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE recycling_posts
 
 CREATE TABLE scraps
 (
-    id         BIGINT PRIMARY KEY,
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
     post_id    BIGINT    NOT NULL,
     user_id    BIGINT    NOT NULL,
     created_at TIMESTAMP NOT NULL,
@@ -139,7 +139,7 @@ CREATE TABLE scraps
 
 CREATE TABLE popular_posts
 (
-    id       BIGINT PRIMARY KEY,
+    id       BIGINT PRIMARY KEY AUTO_INCREMENT,
     post_id  BIGINT      NOT NULL,
     `period` VARCHAR(20) NOT NULL,
     `rank`   BIGINT      NOT NULL,
@@ -149,7 +149,7 @@ CREATE TABLE popular_posts
 
 CREATE TABLE recycling_images
 (
-    id           BIGINT PRIMARY KEY,
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
     recycling_id BIGINT       NOT NULL,
     image_url    VARCHAR(255) NOT NULL,
     created_at   TIMESTAMP    NOT NULL,
@@ -159,7 +159,7 @@ CREATE TABLE recycling_images
 
 CREATE TABLE comments
 (
-    id           BIGINT PRIMARY KEY,
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
     recycling_id BIGINT    NOT NULL,
     user_id      BIGINT    NOT NULL,
     parent_id    BIGINT,


### PR DESCRIPTION
## ✨ 작업 내용
-  카테고리 CRUD 구현
- 글로벌 및 카테고리 커스텀 예외 구현

## 🔎 주요 변경 이유
- 

## 🧪 테스트 방법
- 포스트맨과 h2 사용
<img width="1408" height="649" alt="image" src="https://github.com/user-attachments/assets/a3af4d43-68a5-44f4-8500-1f51aef49998" />
<img width="1395" height="627" alt="image" src="https://github.com/user-attachments/assets/8b8d3967-b332-4867-919f-401e7a686a24" />


## 참고
- 관련 이슈: #4 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리 관리 API 추가: 조회(단건/목록), 생성, 수정, 소프트 삭제 및 영구 삭제 지원

* **개선 사항**
  * 통합된 API 예외 처리로 일관된 에러 응답 제공 및 HTTP 상태 매핑 개선
  * 표준화된 오류 코드/응답 구조 도입
  * 카테고리 중복 검증과 삭제 상태 처리 강화
  * DB 스키마 확장: 자동증가 PK 및 생성/수정/삭제 타임스탬프 등 메타데이터 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->